### PR TITLE
Increase index for new blocks by 1

### DIFF
--- a/amazonpolly.py
+++ b/amazonpolly.py
@@ -35,7 +35,7 @@ def pollytext(filename,pollyvoice):
             end = rest.find(" ", 1000)
 
         textBlock = rest[begin:end]
-        rest = rest[end:]
+        rest = rest[end+1:] #Remove the annoying "Dot" that otherwise starts each new block since you no longer start on that index.
         textBlocks.append(textBlock)
     textBlocks.append(rest)
 
@@ -66,11 +66,3 @@ def pollytext(filename,pollyvoice):
 
 
 pollytext('bookwormvol1.txt','Amy')
-
-
-
-
-
-
-
-


### PR DESCRIPTION
I found it incredibly annoying that the voice started each new block of text by saying "Dot" so I went in and tried to find out why that happened. After some testing I realized that it was because each new block of text started on the same index the last one ended, which most often was a "." By incrementing the index by 1 I hope to stop that from happening, the one problem I can still see is if the stopping point happened to be the first dot in an ellipsis (...) which some authors use quite frequently. From my own testing this seems to work well, but it can always use more testing.
I would have liked to include a small amount of guaranteed silence before moving on to the next block, to make the flow a bit more natural but I don't know how to simulate that in pure text.
Thank you for making this and your video teaching us how to use it.